### PR TITLE
Make S3 bucket prefix configurable

### DIFF
--- a/lib/backy/configuration.rb
+++ b/lib/backy/configuration.rb
@@ -10,6 +10,7 @@ module Backy
       :s3_access_key,
       :s3_secret,
       :s3_bucket,
+      :s3_prefix,
       :app_name,
       :environment,
       :use_parallel,
@@ -59,6 +60,10 @@ module Backy
 
     def s3_bucket
       @s3_bucket ||= ENV["S3_BUCKET"]
+    end
+
+    def s3_prefix
+      @s3_prefix ||= ENV["S3_PREFIX"].presence || "/db/dump/"
     end
 
     def use_parallel
@@ -113,6 +118,7 @@ module Backy
       @s3_secret = configuration.dig("defaults", "s3", "secret_access_key")
       @s3_region = configuration.dig("defaults", "s3", "region")
       @s3_bucket = configuration.dig("defaults", "s3", "bucket")
+      @s3_prefix = configuration.dig("defaults", "s3", "prefix") || s3_prefix
 
       @pg_host = configuration.dig("defaults", "database", "host")
       @pg_port = configuration.dig("defaults", "database", "port")

--- a/lib/backy/s3.rb
+++ b/lib/backy/s3.rb
@@ -11,6 +11,7 @@ module Backy
     def_delegator "Backy.configuration", :s3_secret, :secret
     def_delegator "Backy.configuration", :s3_bucket, :bucket
     def_delegator "Backy.configuration", :s3_access_key, :access_key
+    def_delegator "Backy.configuration", :s3_prefix, :prefix
 
     def s3
       @s3 ||= Aws::S3::Client.new(region: region, credentials: s3_credentials)

--- a/lib/backy/s3_list.rb
+++ b/lib/backy/s3_list.rb
@@ -2,12 +2,6 @@ module Backy
   class S3List
     include S3
 
-    DEFAULT_PREFIX = "db/dump/"
-
-    def initialize(prefix: nil)
-      @prefix = prefix || DEFAULT_PREFIX
-    end
-
     def call
       return [] unless s3_configured?
 
@@ -23,9 +17,5 @@ module Backy
 
       result.sort
     end
-
-    private
-
-    attr_reader :prefix
   end
 end


### PR DESCRIPTION
Currently it's just `/db/dump/` but we're using a bucket with backups for multiple projects, organized in folders. Being able to configure the prefix can be useful.